### PR TITLE
Fix handling of negative values in rounded corners

### DIFF
--- a/R/geom-col-rounded.R
+++ b/R/geom-col-rounded.R
@@ -132,15 +132,14 @@ GeomColRounded <- ggplot2::ggproto(
     grobs <- lapply(
       seq_along(coords$xmin),
       function(i) {
-        is_negative <- data$y[i] < 0
-
-        # For the rectGrob, adjust the y position based on sign
+        # After position adjustments, `y` can be the bar boundary rather than
+        # the signed extent, so infer negativity from the interval.
+        is_negative <- data$ymin[i] < 0
+        rect_height <- (coords$ymax[i] - coords$ymin[i]) / 2
         rect_y <- if (is_negative) {
-          # top half for negatives
-          coords$ymin[i] + (coords$ymax[i] - coords$ymin[i]) / 2 
+          coords$ymin[i] + rect_height
         } else {
-           # bottom half for positives
-          coords$ymax[i] - (coords$ymax[i] - coords$ymin[i]) / 2 
+          coords$ymax[i] - rect_height
         }
 
         gridGeometry::polyclipGrob(
@@ -157,7 +156,7 @@ GeomColRounded <- ggplot2::ggproto(
             coords$xmin[i],
             rect_y,
             width = (coords$xmax[i] - coords$xmin[i]),
-            height = (coords$ymax[i] - coords$ymin[i]) / 2,
+            height = rect_height,
             default.units = "native",
             just = c("left", if (is_negative) "bottom" else "top")
           ),

--- a/R/geom-col-rounded.R
+++ b/R/geom-col-rounded.R
@@ -132,6 +132,17 @@ GeomColRounded <- ggplot2::ggproto(
     grobs <- lapply(
       seq_along(coords$xmin),
       function(i) {
+        is_negative <- data$y[i] < 0
+
+        # For the rectGrob, adjust the y position based on sign
+        rect_y <- if (is_negative) {
+          # top half for negatives
+          coords$ymin[i] + (coords$ymax[i] - coords$ymin[i]) / 2 
+        } else {
+           # bottom half for positives
+          coords$ymax[i] - (coords$ymax[i] - coords$ymin[i]) / 2 
+        }
+
         gridGeometry::polyclipGrob(
           grid::roundrectGrob(
             coords$xmin[i],
@@ -144,11 +155,11 @@ GeomColRounded <- ggplot2::ggproto(
           ),
           grid::rectGrob(
             coords$xmin[i],
-            coords$ymax[i] - (coords$ymax[i] - coords$ymin[i]) / 2,
+            rect_y,
             width = (coords$xmax[i] - coords$xmin[i]),
             height = (coords$ymax[i] - coords$ymin[i]) / 2,
             default.units = "native",
-            just = c("left", "top")
+            just = c("left", if (is_negative) "bottom" else "top")
           ),
           op = "union",
           gp = grid::gpar(

--- a/tests/testthat/_snaps/geom-col-rounded/geom-col-rounded-negative.svg
+++ b/tests/testthat/_snaps/geom-col-rounded/geom-col-rounded-negative.svg
@@ -1,0 +1,62 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' class='svglite' data-engine-version='2.0' width='720.00pt' height='576.00pt' viewBox='0 0 720.00 576.00'>
+<defs>
+  <style type='text/css'><![CDATA[
+    .svglite line, .svglite polyline, .svglite polygon, .svglite path, .svglite rect, .svglite circle {
+      fill: none;
+      stroke: #000000;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      stroke-miterlimit: 10.00;
+    }
+  ]]></style>
+</defs>
+<rect width='100%' height='100%' style='stroke: none; fill: #FFFFFF;'/>
+<defs>
+  <clipPath id='cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA='>
+    <rect x='0.00' y='0.00' width='720.00' height='576.00' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<rect x='0.00' y='0.00' width='720.00' height='576.00' style='stroke-width: 1.07; stroke: #FFFFFF; fill: #FFFFFF;' />
+</g>
+<defs>
+  <clipPath id='cpMzAuODN8NzE0LjUyfDIyLjc4fDU0NS4xMQ=='>
+    <rect x='30.83' y='22.78' width='683.69' height='522.33' />
+  </clipPath>
+</defs>
+<g clip-path='url(#cpMzAuODN8NzE0LjUyfDIyLjc4fDU0NS4xMQ==)'>
+<rect x='30.83' y='22.78' width='683.69' height='522.33' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' />
+<line x1='30.83' y1='308.51' x2='714.52' y2='308.51' style='stroke-width: 1.07; stroke-dasharray: 1.42,4.27; stroke-linecap: butt;' />
+<path d='M 201.70 123.55 L 201.55 122.93 L 201.30 122.34 L 200.95 121.80 L 200.53 121.32 L 200.03 120.91 L 199.48 120.59 L 198.88 120.37 L 198.25 120.24 L 197.77 120.21 L 59.23 120.21 L 59.71 120.24 L 59.07 120.21 L 58.43 120.29 L 57.82 120.47 L 57.24 120.74 L 56.71 121.11 L 56.25 121.55 L 55.86 122.06 L 55.57 122.63 L 55.36 123.24 L 55.26 123.87 L 55.25 124.19 L 55.25 308.51 L 201.75 308.51 L 201.75 124.19 Z' style='fill-rule: nonzero; fill: #595959; stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<path d='M 218.03 308.51 L 218.03 460.08 L 218.04 459.76 L 218.04 460.40 L 218.15 461.03 L 218.35 461.64 L 218.65 462.21 L 219.03 462.72 L 219.50 463.16 L 220.02 463.53 L 220.60 463.80 L 221.22 463.98 L 221.86 464.06 L 222.02 464.06 L 360.55 464.06 L 360.39 464.06 L 361.03 464.03 L 361.66 463.90 L 362.26 463.68 L 362.81 463.36 L 363.31 462.95 L 363.74 462.47 L 364.08 461.93 L 364.33 461.34 L 364.48 460.72 L 364.54 460.08 L 364.54 308.51 Z' style='fill-rule: nonzero; fill: #595959; stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<path d='M 527.27 49.87 L 527.11 49.25 L 526.86 48.66 L 526.52 48.12 L 526.09 47.64 L 525.60 47.23 L 525.04 46.91 L 524.44 46.68 L 523.81 46.55 L 523.33 46.53 L 384.80 46.53 L 385.28 46.55 L 384.64 46.53 L 384.00 46.61 L 383.39 46.78 L 382.81 47.06 L 382.28 47.42 L 381.82 47.87 L 381.43 48.38 L 381.13 48.95 L 380.93 49.56 L 380.83 50.19 L 380.81 50.51 L 380.81 308.51 L 384.80 308.51 L 384.80 308.51 L 523.33 308.51 L 523.33 308.51 L 527.32 308.51 L 527.32 50.51 Z' style='fill-rule: nonzero; fill: #595959; stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<path d='M 543.60 308.51 L 543.60 517.39 L 543.61 517.06 L 543.61 517.71 L 543.71 518.34 L 543.92 518.95 L 544.21 519.52 L 544.60 520.03 L 545.06 520.47 L 545.59 520.84 L 546.17 521.11 L 546.79 521.29 L 547.42 521.37 L 547.58 521.37 L 686.12 521.37 L 685.96 521.37 L 686.60 521.34 L 687.23 521.21 L 687.83 520.99 L 688.38 520.66 L 688.88 520.26 L 689.30 519.78 L 689.65 519.24 L 689.90 518.65 L 690.05 518.02 L 690.10 517.39 L 690.10 308.51 Z' style='fill-rule: nonzero; fill: #595959; stroke-width: 1.07; stroke: none; stroke-linecap: butt;' />
+<rect x='30.83' y='22.78' width='683.69' height='522.33' style='stroke-width: 1.07; stroke: #333333;' />
+</g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
+<text x='25.90' y='475.28' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='7.82px' lengthAdjust='spacingAndGlyphs'>-2</text>
+<text x='25.90' y='393.41' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='7.82px' lengthAdjust='spacingAndGlyphs'>-1</text>
+<text x='25.90' y='311.54' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>0</text>
+<text x='25.90' y='229.67' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>1</text>
+<text x='25.90' y='147.80' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>2</text>
+<text x='25.90' y='65.93' text-anchor='end' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>3</text>
+<polyline points='28.09,472.25 30.83,472.25 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='28.09,390.38 30.83,390.38 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='28.09,308.51 30.83,308.51 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='28.09,226.64 30.83,226.64 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='28.09,144.77 30.83,144.77 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='28.09,62.90 30.83,62.90 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='128.50,547.85 128.50,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='291.28,547.85 291.28,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='454.07,547.85 454.07,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<polyline points='616.85,547.85 616.85,545.11 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' />
+<text x='128.50' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>a</text>
+<text x='291.28' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>b</text>
+<text x='454.07' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.40px' lengthAdjust='spacingAndGlyphs'>c</text>
+<text x='616.85' y='556.10' text-anchor='middle' style='font-size: 8.80px; fill: #4D4D4D; font-family: sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>d</text>
+<text x='372.67' y='568.24' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='5.50px' lengthAdjust='spacingAndGlyphs'>x</text>
+<text transform='translate(13.05,283.95) rotate(-90)' text-anchor='middle' style='font-size: 11.00px; font-family: sans;' textLength='5.50px' lengthAdjust='spacingAndGlyphs'>y</text>
+<text x='30.83' y='14.56' style='font-size: 13.20px; font-family: sans;' textLength='161.45px' lengthAdjust='spacingAndGlyphs'>geom-col-rounded-negative</text>
+</g>
+</svg>

--- a/tests/testthat/test-geom-col-rounded.R
+++ b/tests/testthat/test-geom-col-rounded.R
@@ -1,6 +1,14 @@
 df <- data.frame(x = letters[1:3], y = c(2.3, 1.9, 3.2))
 p <-  ggplot2::ggplot(df, ggplot2::aes(x, y)) + geom_col_rounded()
+df_negative <- data.frame(x = letters[1:4], y = c(2.3, -1.9, 3.2, -2.6))
+p_negative <- ggplot2::ggplot(df_negative, ggplot2::aes(x, y)) +
+  ggplot2::geom_hline(yintercept = 0, linetype = "dotted") +
+  geom_col_rounded()
 
 test_that("geom_col_rounded() works", {
   vdiffr::expect_doppelganger("geom-col-rounded", p)
+})
+
+test_that("geom_col_rounded() works with negative values", {
+  vdiffr::expect_doppelganger("geom-col-rounded-negative", p_negative)
 })


### PR DESCRIPTION
Adjust the rendering of rounded corners to correctly account for negative values, ensuring corners round at the furthermost edge from zero.

Solves #5